### PR TITLE
dbsetup: load user csv

### DIFF
--- a/container/dbsetup/run.sh
+++ b/container/dbsetup/run.sh
@@ -51,8 +51,9 @@ gsutil cp $newest_dump_uri "/tmp/$newest_dump"
 log_info "downloaded newest dump $newest_dump"
 unzip -o "/tmp/$newest_dump" -d /tmp || { log_error "unzip of dump file failed"; exit 1; }
 mysql $connect serlo < "/tmp/dump.sql" || { log_error "import of dump failed"; exit 1; }
+mysql $connect -e "LOAD DATA LOCAL INFILE 'user.csv' INTO TABLE user FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' IGNORE 1 ROWS;" serlo || { log_error "import of dump failed"; exit 1; }
 log_info "imported serlo database dump $newest_dump"
 
 # delete all unnecessary files
 rm -f $(ls /tmp/dump*.zip | grep -v $newest_dump)
-rm $(ls /tmp/dump.sql)
+rm /tmp/dump.sql /tmp/user.csv


### PR DESCRIPTION
The user table is no longer dumped with the other tables, but stored as a separate csv file.
This needs to be reflected in the dbsetup.