### PR TITLE
Tries to fix `permission denied for relation session_token_exchanges`

### DIFF
--- a/container/dbdump/Makefile
+++ b/container/dbdump/Makefile
@@ -4,7 +4,7 @@ local_image=serlo/$(image_name)
 # change version if you want to push a new image
 major_version=3
 minor_version=2
-patch_version=2
+patch_version=1
 version=$(major_version).$(minor_version).$(patch_version)
 
 include ../../mk/dockerci.mk

--- a/container/dbdump/Makefile
+++ b/container/dbdump/Makefile
@@ -4,7 +4,7 @@ local_image=serlo/$(image_name)
 # change version if you want to push a new image
 major_version=3
 minor_version=2
-patch_version=1
+patch_version=3
 version=$(major_version).$(minor_version).$(patch_version)
 
 include ../../mk/dockerci.mk

--- a/container/dbdump/Makefile
+++ b/container/dbdump/Makefile
@@ -4,7 +4,7 @@ local_image=serlo/$(image_name)
 # change version if you want to push a new image
 major_version=3
 minor_version=2
-patch_version=0
+patch_version=1
 version=$(major_version).$(minor_version).$(patch_version)
 
 include ../../mk/dockerci.mk

--- a/container/dbdump/Makefile
+++ b/container/dbdump/Makefile
@@ -4,7 +4,7 @@ local_image=serlo/$(image_name)
 # change version if you want to push a new image
 major_version=3
 minor_version=2
-patch_version=1
+patch_version=2
 version=$(major_version).$(minor_version).$(patch_version)
 
 include ../../mk/dockerci.mk

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -35,7 +35,7 @@ pg_ctl start -D /var/lib/postgresql/data
 psql --quiet -c "CREATE user serlo;"
 psql --quiet -c "CREATE user serlo_readonly;"
 psql --quiet -c "CREATE database kratos;"
-psql --quiet -c "GRANT ALL PRIVILEGES ON DATABASE kratos TO serlo;"
+psql --quiet -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO serlo;"
 psql --quiet -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO serlo_readonly;"
 psql -d kratos <temp.sql
 rm temp.sql

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -47,7 +47,6 @@ psql --quiet kratos -c "UPDATE identity_verifiable_addresses SET value = CONCAT(
 psql --quiet kratos -c "UPDATE identity_recovery_addresses SET value = CONCAT(identity_id, '@localhost');"
 psql --quiet kratos -c "UPDATE identity_credential_identifiers SET identifier = CONCAT(ic.identity_id, '@localhost') FROM (select id, identity_id FROM identity_credentials) AS ic where ic.id = identity_credential_id and identifier LIKE '%@%';"
 psql --quiet kratos -c "TRUNCATE sessions, continuity_containers, courier_messages, identity_verification_codes, identity_recovery_codes, identity_recovery_tokens, identity_verification_tokens, selfservice_errors, selfservice_login_flows, selfservice_recovery_flows, selfservice_registration_flows, selfservice_settings_flows, selfservice_verification_flows, session_devices, session_token_exchanges CASCADE;"
-sleep 3
 pg_dump kratos >kratos.sql
 
 log_info "compress database dump"

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -35,7 +35,7 @@ pg_ctl start -D /var/lib/postgresql/data
 psql --quiet -c "CREATE user serlo;"
 psql --quiet -c "CREATE user serlo_readonly;"
 psql --quiet -c "CREATE database kratos;"
-psql --quiet -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO serlo;"
+psql --quiet -c "GRANT ALL PRIVILEGES ON DATABASE kratos TO serlo;"
 psql --quiet -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO serlo_readonly;"
 psql -d kratos <temp.sql
 rm temp.sql

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -47,6 +47,7 @@ psql --quiet kratos -c "UPDATE identity_verifiable_addresses SET value = CONCAT(
 psql --quiet kratos -c "UPDATE identity_recovery_addresses SET value = CONCAT(identity_id, '@localhost');"
 psql --quiet kratos -c "UPDATE identity_credential_identifiers SET identifier = CONCAT(ic.identity_id, '@localhost') FROM (select id, identity_id FROM identity_credentials) AS ic where ic.id = identity_credential_id and identifier LIKE '%@%';"
 psql --quiet kratos -c "TRUNCATE sessions, continuity_containers, courier_messages, identity_verification_codes, identity_recovery_codes, identity_recovery_tokens, identity_verification_tokens, selfservice_errors, selfservice_login_flows, selfservice_recovery_flows, selfservice_registration_flows, selfservice_settings_flows, selfservice_verification_flows, session_devices, session_token_exchanges CASCADE;"
+sleep 3
 pg_dump kratos >kratos.sql
 
 log_info "compress database dump"


### PR DESCRIPTION
This PR doesn't bring anything new. The tries in versions 3.2.1 and 3.2.2 didn't work, so I've just reverted it back. Even though, I think it is important to documentate these changes, since the correspondent images are in our registry.

At the end of the day, I had to manually log in into the postgres instance with the user `serlo` and run:
`GRANT SELECT ON ALL TABLES IN SCHEMA public TO serlo_readonly;`
This grant seems to not work at the script `container/dbdump/run.sh` since the user serlo_readonly doesn't have corresponding privileges.