### PR TITLE
fix(dbdump): remove deleted tables from tables to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Infrastructure Images are project independent docker images. The images are eith
 
 The build is based mainly on docker. Only installation of Make is required.
 
-You can get a list of all supported goals typing ```make help```.
+You can get a list of all supported goals typing `make help`.
+
+### Building specific images manually
+
+Use `make build_ci_?` (replace ? for the name of the image, v.g. `make build_ci_dbdump`)
+for building and pushing to registry a specific image manually.
 
 ### build_images_minikube
 
@@ -18,7 +23,8 @@ Builds images for Minikube regardsless of any existence.
 
 ### build_images_ci
 
-Builds images in ci environment and pushes them to eu.gcr.io
+Builds images in ci environment and pushes them to eu.gcr.io.
+Note: Currently not working, because Github workflow is missing.
 
 # Images
 

--- a/container/dbdump/Makefile
+++ b/container/dbdump/Makefile
@@ -3,7 +3,7 @@ local_image=serlo/$(image_name)
 
 # change version if you want to push a new image
 major_version=3
-minor_version=3
+minor_version=4
 patch_version=0
 version=$(major_version).$(minor_version).$(patch_version)
 

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -21,7 +21,7 @@ log_info "dump legacy serlo database schema"
 
 mysqldump $mysql_connect --no-data --lock-tables=false --add-drop-database serlo >mysql.sql
 
-for table in ad ad_page attachment_container attachment_file blog_post comment comment_status comment_vote entity entity_link entity_revision entity_revision_field event event_log event_parameter event_parameter_name event_parameter_string event_parameter_uuid flag instance instance_permission language license metadata metadata_key migrations navigation_container navigation_page navigation_parameter navigation_parameter_key notification notification_event page_repository page_repository_role page_revision permission related_content related_content_category related_content_container related_content_external related_content_internal role role_inheritance role_permission role_user subscription taxonomy term term_taxonomy term_taxonomy_comment term_taxonomy_entity type url_alias uuid; do
+for table in comment comment_status entity entity_link entity_revision entity_revision_field event event_log event_parameter event_parameter_name event_parameter_string event_parameter_uuid instance license migrations notification notification_event page_repository page_revision role role_user subscription taxonomy term term_taxonomy term_taxonomy_entity type url_alias uuid; do
     mysqldump $mysql_connect --no-create-info --lock-tables=false --add-locks serlo $table >>mysql.sql
 done
 # just dump teachers for data protection reasons

--- a/container/dbdump/run.sh
+++ b/container/dbdump/run.sh
@@ -21,9 +21,8 @@ log_info "dump legacy serlo database schema"
 
 mysqldump $mysql_connect --no-data --lock-tables=false --add-drop-database serlo >mysql.sql
 
-for table in comment comment_status entity entity_link entity_revision entity_revision_field event event_log event_parameter event_parameter_name event_parameter_string event_parameter_uuid instance license migrations notification notification_event page_repository page_revision role role_user subscription taxonomy term term_taxonomy term_taxonomy_entity type url_alias uuid; do
-    mysqldump $mysql_connect --no-create-info --lock-tables=false --add-locks serlo $table >>mysql.sql
-done
+mysqldump $mysql_connect --no-create-info --lock-tables=false --add-locks --ignore-table=serlo.user serlo >>mysql.sql
+
 # just dump teachers for data protection reasons
 mysqldump $mysql_connect --no-create-info --lock-tables=false --add-locks --where "field = 'interests' and value = 'teacher'" serlo user_field >>mysql.sql
 mysql $mysql_connect --batch -e "SELECT id, CONCAT(@rn:=@rn+1, '@localhost') AS email, username, '8a534960a8a4c8e348150a0ae3c7f4b857bfead4f02c8cbf0d' AS password, logins, date, CONCAT(@rn:=@rn+1, '') AS token, last_login, description FROM user, (select @rn:=2) r;" serlo >user.csv


### PR DESCRIPTION
Tables got deleted with https://github.com/serlo/db-migrations/blob/main/src/20231127000000-delete-unused-tables.ts, so we must not try to copy them for the dump.

It would be nicer if we could do the dump without explicitly listing all tables, so that making the dump does not break whenever a table is deleted without modifying this script accordingly.